### PR TITLE
fix: add declaration files for composables

### DIFF
--- a/packages/form-actions-nuxt/build.config.ts
+++ b/packages/form-actions-nuxt/build.config.ts
@@ -2,5 +2,6 @@ import { defineBuildConfig } from "unbuild"
 
 export default defineBuildConfig({
   entries: ["src/module"],
+  declaration: true,
   failOnWarn: false
 })

--- a/packages/form-actions-nuxt/package.json
+++ b/packages/form-actions-nuxt/package.json
@@ -36,6 +36,7 @@
     "dts": "esno scripts/dts.ts",
     "readme": "esno scripts/readme.ts",
     "postbuild": "pnpm dts && pnpm readme",
+    "build:stub": "nuxt-build-module --stub",
     "build:module": "nuxt-build-module",
     "build": "rimraf dist && pnpm build:module && pnpm postbuild",
     "postinstall": "nuxi prepare",

--- a/packages/form-actions-nuxt/src/runtime/composables/useFormAction.d.ts
+++ b/packages/form-actions-nuxt/src/runtime/composables/useFormAction.d.ts
@@ -1,7 +1,7 @@
-import type { ErrorRef, UseFormAction } from "../types"
-import type { LoaderName, Loaders } from "#build/types/loader-types.d.ts"
 import type { ComputedRef } from "vue"
 import type { FetchError } from "ofetch"
+import type { ErrorRef, UseFormAction } from "../types"
+import type { LoaderName, Loaders } from "#build/types/loader-types.d.ts"
 
 /**
  * Use form action does the following :

--- a/packages/form-actions-nuxt/src/runtime/composables/useFormAction.d.ts
+++ b/packages/form-actions-nuxt/src/runtime/composables/useFormAction.d.ts
@@ -1,0 +1,27 @@
+import type { ErrorRef, UseFormAction } from "../types"
+import type { LoaderName, Loaders } from "#build/types/loader-types.d.ts"
+import type { ComputedRef } from "vue"
+import type { FetchError } from "ofetch"
+
+/**
+ * Use form action does the following :
+ * - Get the data from the loader
+ * - Listen to the form submission
+ * - Handle custom logic and optimistic updates
+ * - Submit the form data to the server
+ * - Refresh the loader
+ * - Handle CSR navigation / error
+ */
+export declare function useFormAction<Name extends LoaderName>({ run, loader, loaderOptions }?: UseFormAction<Name>): Promise<{
+    data: ComputedRef<{
+        loader: Loaders[Name] | null;
+        formResponse: Record<string, unknown>;
+        actionResponse: Record<string, unknown>;
+    }>;
+    loading: ComputedRef<boolean>;
+    error: ComputedRef<ErrorRef | FetchError<any> | undefined>;
+    enhance: {
+        setElement(el: HTMLFormElement): void;
+        cleanup(): void;
+    };
+}>

--- a/packages/form-actions-nuxt/src/runtime/composables/useFormAction.ts
+++ b/packages/form-actions-nuxt/src/runtime/composables/useFormAction.ts
@@ -1,64 +1,9 @@
-import { type Ref, computed, reactive, ref } from "vue"
+import { computed, reactive, ref } from "vue"
 import { NUXT_PE_HEADER } from "../utils"
+import type { ActionResponsePayload, ErrorRef, UpdateFunction, UseFormAction } from "../types"
 import { getActionName, getLoaderUrl, useLoader } from "./useLoader"
 import { createError, navigateTo, useRoute } from "#imports"
-import type { LoaderName, LoaderOptions, Loaders } from "#build/types/loader-types.d.ts"
-
-interface UseFormAction<N extends LoaderName> { run?: ActionFunction<N>; loader?: N; loaderOptions?: LoaderOptions }
-
-type ActionFunction<N extends LoaderName> = (args: ActionFunctionArgs<N>) => void
-
-type UpdateFunction<N extends LoaderName> = (args: UpdateArguments<N>) => void
-
-interface UpdateArguments<N extends LoaderName> { result: Ref<Loaders[N]> }
-interface ActionFunctionArgs<N extends LoaderName> {
-  /**
-   * Cancel the default submission.
-   */
-  cancel: () => void
-  /**
-   * Handle optimistic updates
-   *
-   * @param update Update callback to update the result.
-   */
-  optimistic: (update: UpdateFunction<N>) => void
-  /**
-   * An object version of the `FormData` from this form
-   */
-  formData: Record<string, any>
-  /**
-   * The original submit event.
-   */
-  event: SubmitEvent
-  /**
-   * The name of the action.
-   */
-  action: string
-  /**
-   * The form element.
-   */
-  form: HTMLFormElement
-  /**
-   * The Element that submitted.
-   */
-  submitter: HTMLElement
-  /**
-   * The loader URL.
-   */
-  loader: string | undefined
-  /**
-   * The default submit function.
-   */
-  submitForm: () => Promise<void>
-}
-
-type ActionResponsePayload = Response & { _data: { data: Record<string, any>; action: Record<string, any> } }
-
-interface ErrorRef {
-  statusCode: number
-  statusMessage: string
-  data: any
-}
+import type { LoaderName } from "#build/types/loader-types.d.ts"
 
 /**
  * Use form action does the following :
@@ -71,8 +16,8 @@ interface ErrorRef {
  */
 export async function useFormAction<Name extends LoaderName>({ run, loader, loaderOptions }: UseFormAction<Name> = {}) {
   const form = ref<HTMLFormElement>()
-  const formResponse = ref<Record<string, any>>({})
-  const actionResponse = ref<Record<string, any>>({})
+  const formResponse = ref<Record<string, unknown>>({})
+  const actionResponse = ref<Record<string, unknown>>({})
   const cancelDefaultSubmit = ref(false)
   const error = ref<ErrorRef>()
 
@@ -83,8 +28,8 @@ export async function useFormAction<Name extends LoaderName>({ run, loader, load
     if (!response.headers.has(NUXT_PE_HEADER)) return
     const { data, action } = response?._data
     // console.log('Handling response ...', action, data)
-    actionResponse.value = action
-    formResponse.value = data
+    actionResponse.value = action ?? {}
+    formResponse.value = data ?? {}
     // CSR redirect
     if (action && action.redirect) navigateTo(action.redirect)
 

--- a/packages/form-actions-nuxt/src/runtime/composables/useLoader.d.ts
+++ b/packages/form-actions-nuxt/src/runtime/composables/useLoader.d.ts
@@ -1,0 +1,9 @@
+import type { FetchResult, Loaders, LoaderName, LoaderOptions } from "#build/types/loader-types.d.ts"
+import type { Ref } from "vue"
+/**
+ * Return data from a loader with type-safety.
+ * @param loader Loader
+ * @returns
+ */
+export declare function useLoader<Name extends LoaderName>(loader?: Name | undefined | false, loaderOptions?: LoaderOptions):
+  Promise<FetchResult<Loaders[Name]> | { result: Ref<null>; refresh: () => void; pending: Ref<boolean>; error: Ref<null> }>

--- a/packages/form-actions-nuxt/src/runtime/composables/useLoader.d.ts
+++ b/packages/form-actions-nuxt/src/runtime/composables/useLoader.d.ts
@@ -1,5 +1,5 @@
-import type { FetchResult, Loaders, LoaderName, LoaderOptions } from "#build/types/loader-types.d.ts"
 import type { Ref } from "vue"
+import type { FetchResult, Loaders, LoaderName, LoaderOptions } from "#build/types/loader-types.d.ts"
 /**
  * Return data from a loader with type-safety.
  * @param loader Loader

--- a/packages/form-actions-nuxt/src/runtime/composables/useLoader.ts
+++ b/packages/form-actions-nuxt/src/runtime/composables/useLoader.ts
@@ -4,7 +4,7 @@ import { NITRO_LOADER_PREFIX } from "../utils"
 import { useFetch, useRoute } from "#imports"
 import type { FetchNuxtLoaderFunction, LoaderName, LoaderOptions } from "#build/types/loader-types.d.ts"
 
-export type Loader = | LoaderName | undefined | false
+type Loader = | LoaderName | undefined | false
 
 const getLoaderName = (loaderName: LoaderName) => `/${NITRO_LOADER_PREFIX}/${loaderName}` as const
 const lastSubpath = (path: string) => path.split("/").pop() as string
@@ -17,7 +17,7 @@ export const getLoaderUrl = (loader: Loader) => validLoaderName(loader) ? getLoa
  * @param loader Loader
  * @returns
  */
-export function useLoader<Name extends LoaderName>(loader?: Name | undefined | false, loaderOptions?: LoaderOptions) {
+export async function useLoader<Name extends LoaderName>(loader?: Name | undefined | false, loaderOptions?: LoaderOptions) {
   const fetchNuxtLoader: FetchNuxtLoaderFunction<Name> = async (url: string, loaderOptions?: LoaderOptions) => {
     const { data: result, refresh, pending, error } = await useFetch(url, { immediate: true, params: useRoute().params, ...loaderOptions })
     return { result, refresh, pending, error } // Because we're forcing the return, we get a static type here.

--- a/packages/form-actions-nuxt/src/runtime/types.ts
+++ b/packages/form-actions-nuxt/src/runtime/types.ts
@@ -1,0 +1,58 @@
+import { type Ref } from "vue"
+import type { LoaderName, LoaderOptions, Loaders } from "#build/types/loader-types.d.ts"
+
+export interface UseFormAction<N extends LoaderName> { run?: ActionFunction<N>; loader?: N; loaderOptions?: LoaderOptions }
+
+export type ActionFunction<N extends LoaderName> = (args: ActionFunctionArgs<N>) => void
+
+export type UpdateFunction<N extends LoaderName> = (args: UpdateArguments<N>) => void
+
+export interface UpdateArguments<N extends LoaderName> { result: Ref<Loaders[N]> }
+export interface ActionFunctionArgs<N extends LoaderName> {
+  /**
+   * Cancel the default submission.
+   */
+  cancel: () => void
+  /**
+   * Handle optimistic updates
+   *
+   * @param update Update callback to update the result.
+   */
+  optimistic: (update: UpdateFunction<N>) => void
+  /**
+   * An object version of the `FormData` from this form
+   */
+  formData: Record<string, unknown>
+  /**
+   * The original submit event.
+   */
+  event: SubmitEvent
+  /**
+   * The name of the action.
+   */
+  action: string
+  /**
+   * The form element.
+   */
+  form: HTMLFormElement
+  /**
+   * The Element that submitted.
+   */
+  submitter: HTMLElement
+  /**
+   * The loader URL.
+   */
+  loader: string | undefined
+  /**
+   * The default submit function.
+   */
+  submitForm: () => Promise<void>
+}
+
+export type ActionResponsePayload = Response & { _data: { data?: Record<string, any>; action?: Record<string, any> } }
+
+export interface ErrorRef {
+  statusCode: number
+  statusMessage: string
+  data: unknown
+}

--- a/packages/form-actions-nuxt/src/runtime/types.ts
+++ b/packages/form-actions-nuxt/src/runtime/types.ts
@@ -1,14 +1,15 @@
 import { type Ref } from "vue"
 import type { LoaderName, LoaderOptions, Loaders } from "#build/types/loader-types.d.ts"
 
-export interface UseFormAction<N extends LoaderName> { run?: ActionFunction<N>; loader?: N; loaderOptions?: LoaderOptions }
-
-export type ActionFunction<N extends LoaderName> = (args: ActionFunctionArgs<N>) => void
-
 export type UpdateFunction<N extends LoaderName> = (args: UpdateArguments<N>) => void
 
-export interface UpdateArguments<N extends LoaderName> { result: Ref<Loaders[N]> }
-export interface ActionFunctionArgs<N extends LoaderName> {
+interface UpdateArguments<N extends LoaderName> { result: Ref<Loaders[N]> }
+
+export interface UseFormAction<N extends LoaderName> { run?: ActionFunction<N>; loader?: N; loaderOptions?: LoaderOptions }
+
+type ActionFunction<N extends LoaderName> = (args: ActionFunctionArgs<N>) => void
+
+interface ActionFunctionArgs<N extends LoaderName> {
   /**
    * Cancel the default submission.
    */

--- a/playgrounds/advanced/nuxt.config.ts
+++ b/playgrounds/advanced/nuxt.config.ts
@@ -1,5 +1,5 @@
 export default defineNuxtConfig({
-  modules: ["@hebilicious/server-block-nuxt", "../packages/form-actions-nuxt/src/module.ts"],
+  modules: ["@hebilicious/server-block-nuxt", "@hebilicious/form-actions-nuxt"],
   devtools: {
     enabled: true
   }

--- a/playgrounds/advanced/package.json
+++ b/playgrounds/advanced/package.json
@@ -7,6 +7,7 @@
     "start": "nuxi preview"
   },
   "devDependencies": {
+    "@hebilicious/form-actions-nuxt": "latest",
     "@hebilicious/server-block-nuxt": "0.3.4",
     "@hebilicious/sfc-server-volar": "0.3.4",
     "@nuxt/devtools": "^0.7.5",

--- a/playgrounds/vorms-zod/nuxt.config.ts
+++ b/playgrounds/vorms-zod/nuxt.config.ts
@@ -1,5 +1,5 @@
 export default defineNuxtConfig({
-  modules: ["../packages/form-actions-nuxt/src/module.ts"],
+  modules: ["@hebilicious/form-actions-nuxt"],
   devtools: {
     enabled: true
   }

--- a/playgrounds/vorms-zod/package.json
+++ b/playgrounds/vorms-zod/package.json
@@ -7,6 +7,7 @@
     "start": "nuxi preview"
   },
   "devDependencies": {
+    "@hebilicious/form-actions-nuxt": "latest",
     "@nuxt/devtools": "^0.7.5",
     "@vorms/resolvers": "^1.1.0",
     "h3": "^1.8.0-rc.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
 
   playgrounds/advanced:
     devDependencies:
+      '@hebilicious/form-actions-nuxt':
+        specifier: 0.2.0-beta.1
+        version: link:../../packages/form-actions-nuxt
       '@hebilicious/server-block-nuxt':
         specifier: 0.3.4
         version: 0.3.4(@hebilicious/sfc-server-volar@0.3.4)(h3@1.8.0-rc.3)(nitropack@2.5.2)(nuxt@3.6.5)(rollup@3.27.2)(vite@4.4.9)(vue@3.3.4)
@@ -144,6 +147,9 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0(vue@3.3.4)
     devDependencies:
+      '@hebilicious/form-actions-nuxt':
+        specifier: latest
+        version: link:../../packages/form-actions-nuxt
       '@nuxt/devtools':
         specifier: ^0.7.5
         version: 0.7.5(nuxt@3.6.5)(rollup@3.27.2)(vite@4.4.9)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ importers:
   playgrounds/advanced:
     devDependencies:
       '@hebilicious/form-actions-nuxt':
-        specifier: 0.2.0-beta.1
+        specifier: latest
         version: link:../../packages/form-actions-nuxt
       '@hebilicious/server-block-nuxt':
         specifier: 0.3.4


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

Fix https://github.com/Hebilicious/form-actions-nuxt/issues/33

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Due to their complexity, composables return types aren't infered properly by unbuild/rollup-dts, therefore they need to be explicitly defined and maintained in declaration files.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
