### PR TITLE
docs: fix server loader typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ export const loader = defineServerLoader(async () => {
 
 Use them with type-safety everywhere.
 
-`components/Books.ts`
+`components/Books.vue`
 
 ```html
 <script setup lang="ts">


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->


### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)

### 📚 Description

Books component in [Server Loaders](https://github.com/Hebilicious/form-actions-nuxt/blob/04cddd403a77bd2ac52ef3188b44806cf8591ad7/README.md?plain=1#L236) section should be `Books.vue`, but is using `Books.ts`.

Don't understand how I've missed this 🤣

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
