### PR TITLE
docs: switch "User not found" error message for generic "Invalid login"

### DIFF
--- a/docs/content/2.usage/1.form-actions.md
+++ b/docs/content/2.usage/1.form-actions.md
@@ -80,7 +80,7 @@ export default defineFormActions({
     const user = getUser(email, password)
     if (!user) {
       return actionResponse(event, { email, incorrect: true },
-        { error: { message: "No user found" } })
+        { error: { message: "Invalid login" } })
     }
 
     // Attach a session cookie to the response
@@ -120,7 +120,7 @@ const { enhance, data } = await useFormAction()
       Invalid credentials.
     </p>
     <p v-if="data.formResponse?.incorrect" class="error">
-      User does not exists.
+      Invalid login.
     </p>
     <p v-if="data.formResponse?.user" class="success">
       {{ data.formResponse.user.name }} Found !


### PR DESCRIPTION
The idea is here to avoid examples in documentation that suggest developers bad / unsecure behavior when handling authentication workflows.

In this case the "bad / unsecure" behavior would be to disclose information about a user account existing or not. This allows attackers to "fish" for accounts by simply throwing email addresses onto the form and saving the results. See also https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#authentication-responses

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
