### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/1.get-started/2.installation.md
+++ b/docs/content/1.get-started/2.installation.md
@@ -26,21 +26,9 @@ bunx nuxi init
 ::
 
 Install the form-actions module from NPM :
-
-::code-group
-```bash [npm]
-npm install @hebilicious/form-actions-nuxt
+```bash
+npx nuxi@latest module add form-actions-nuxt
 ```
-```bash [pnpm]
-pnpm add @hebilicious/form-actions-nuxt
-```
-```bash [yarn]
-yarn add @hebilicious/form-actions-nuxt
-```
-```bash [bun]
-bun install @hebilicious/form-actions-nuxt
-```
-::
 
 Add it to `modules` in your `nuxt.config`:
 

--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -16,7 +16,7 @@ defineOgImage({
   title,
   description
 })
-const source = ref("npm i @hebilicious/form-actions-nuxt")
+const source = ref("npx nuxi@latest module add form-actions-nuxt
 const { copy, copied } = useClipboard({ source })
 </script>
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description


This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
